### PR TITLE
Remove reference to ServicerBase

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "betterproto"
-version = "2.0.0b5+pachv1.0.0"
+version = "2.0.0b5+pachv1.0.1"
 description = "A better Protobuf / gRPC generator & library"
 authors = ["Daniel G. Taylor <danielgtaylor@gmail.com>"]
 readme = "README.md"

--- a/src/betterproto/grpc/grpcio_server.py
+++ b/src/betterproto/grpc/grpcio_server.py
@@ -1,3 +1,4 @@
+# TODO: This file isn't necessary for clients, might be necessary for servers.
 from typing import Dict, TYPE_CHECKING
 from abc import ABC, abstractmethod
 

--- a/src/betterproto/templates/template.py.j2
+++ b/src/betterproto/templates/template.py.j2
@@ -22,7 +22,6 @@ import betterproto.lib.google.protobuf as betterproto_lib_google_protobuf
 {% endfor %}
 {% if output_file.services%}
 import grpc
-from betterproto.grpc.grpcio_server import ServicerBase
 {% endif %}
 
 from typing import TYPE_CHECKING
@@ -174,7 +173,7 @@ class {{ service.py_name }}Stub:
 {% endfor %}
 
 {% for service in output_file.services %}
-class {{ service.py_name }}Base(ServicerBase):
+class {{ service.py_name }}Base:
     {% if service.comment %}
 {{ service.comment }}
 


### PR DESCRIPTION
This should allow packages to use the real betterproto as a dependency rather than this fork.